### PR TITLE
Version 2.0

### DIFF
--- a/GenericPowershell/Properties/AssemblyInfo.cs
+++ b/GenericPowershell/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Skryptek, LLC")]
 [assembly: AssemblyProduct("ADFS GenericPowershell Attribute Store")]
-[assembly: AssemblyCopyright("Copyright © 2024 Skryptek, LLC")]
+[assembly: AssemblyCopyright("Copyright © 2025 Skryptek, LLC")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/README.md
+++ b/README.md
@@ -7,23 +7,57 @@ This is a simple ADFS Custom Attribute store which provides functionality to use
 
 ### Issuing a new claim:
 ```
- => issue(store = "GenericPowershell", types = ("PwshDate"), query = "Get-Date", param = "");
+ => issue(store = "GenericPowershell", types = ("PwshDate"), query = "Get-Date");
 ```
 This will issue a claim called "PwshDate" with the value of the current date
 
 ### Transforming an existing claim and issuing it as a new claim:
+**NOTE:** You must represent double-quotes in the claims-language query with two backticks (configurable; see below)
 ```
 c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]
- => issue(store = "GenericPowershell", types = ("PwshAccountName"), query = "'{0}{1}' -replace '^DOMAIN\\',''", param = c.Value, param = "helloworld");
+ => issue(store = "GenericPowershell", types = ("PwshAccountName"), query = "``$($args[0] -replace '^DOMAIN\\','')$($args[1])``", param = c.Value, param = "helloworld");
 ```
 This will execute the following powershell:
 ```powershell
-## The GenericPowershell attribute store will do a String.Format on {0} and {1} with the provided parameters
-'{0}{1}' -replace '^DOMAIN\\','' #This returns a string with the domain stripped off and the string "helloworld" appended
+"$($args[0] -replace '^DOMAIN\\','')$($args[1])" #This returns a string with the domain stripped off and the string "helloworld" appended
 ```
 
 The resulting string will be issued as a claim called "PwshAccountName" with value `<windowsaccountname>helloworld`
 
+### Issuing multiple AttributeValue elements for a claim:
+This attribute store supports issuing multiple AttributeValue elements for a claim (like an array of elements).
+This is typically used when issuing a user's group memberships for example.
+The GenericPowershell ADFS Attribute Store will issue one AttributeValue element for each PSObject output to the pipeline.
+
+For example, to issue 3 groups (Group1, Group2, Group3) use the following claims-rule:
+```powershell
+ => issue(
+     store = "GenericPowershell",
+     types = ("Groups"),
+     query = "@('Group1','Group2','Group3')"
+    );
+```
+
+### Escaping double-quotes in the claims-language query:
+You can escape double-quotes in the claims-language query by using two backticks (default behavior).
+If you want to use an alternate escape character sequence, you can configure it in ADFS under:
+`AD FS > Service > Attribute Stores > GenericPowershell > Properties > Optional initialization parameters`
+and define a Name/Value pair called `doubleQuoteEscapeSequence` with the value being your desired escape sequence.
+In theory, you could define a single-quote here to replace all "verbatim strings" with "expanded strings" but results may vary.
+
+Alternatively (for ease of readability), you can use smart quotes in the claims-language query.
+Example:  
+```
+“smart quotation marks”
+```
+would make the above transform query:
+```
+c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]
+   => issue(store = "GenericPowershell",
+      types = ("PwshAccountName"),
+      query = "“$($args[0] -replace '^DOMAIN\\','')$($args[1])”",
+      param = c.Value, param = "helloworld");
+```
 
 ## Installation
 ### If compiling without signing the assembly:


### PR DESCRIPTION
- Eliminated string formatting as method to inject parameters to Powershell code due to code-injection safety concerns (breaking change). Use $args[] now to reference parameters or begin query with a param() block.
- Added feature to return each pipeline object as an additional element in the claim (i.e. returning an array will fill multiple AttributeValue elements in the same SAML Attribute section.)
- Added feature to escape double-quotes with a custom escape sequence (you cannot use double quotes in an ADFS claims-language query to my knowledge). You may also use smart-quote characters (Powershell native feature)